### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/places/templatetags/places_finder.py
+++ b/places/templatetags/places_finder.py
@@ -38,7 +38,7 @@ def places_filter(parser, token):
             raise_error = True
 
     if raise_error:
-        raise template.TemplateSyntaxError, "%r tag must be used with %s" % (tokens[0], "{% categories as categories %}")
+        raise template.TemplateSyntaxError, "{0!r} tag must be used with {1!s}".format(tokens[0], "{% categories as categories %}")
     else:
         return PlacesNode(var_name, filters)
 

--- a/places/widgets.py
+++ b/places/widgets.py
@@ -57,14 +57,14 @@ class GoogleMapPointWidget(forms_gis.BaseGeometryWidget):
 
         javascript = render_to_string('places/javascript/point_gmap.js', context)
 
-        html = self.hidden_input.render("%s" % name, None, dict(id='id_%s' % name))
+        html = self.hidden_input.render("{0!s}".format(name), None, dict(id='id_{0!s}'.format(name)))
         if self.config['allow_bigger']:
-            html += "<button id='min_%s'>-</button>" % name
-            html += "<button id='max_%s'>+</button><br/>" % name
+            html += "<button id='min_{0!s}'>-</button>".format(name)
+            html += "<button id='max_{0!s}'>+</button><br/>".format(name)
         map_options = {
             'name': name,
             'min_width': self.config['min_width'],
             'min_height': self.config['min_height'],
         }
-        html += "<div id=\"map_%(name)s\" style=\"width: %(min_width)spx; height: %(min_height)spx\"></div>" % map_options
+        html += "<div id=\"map_{name!s}\" style=\"width: {min_width!s}px; height: {min_height!s}px\"></div>".format(**map_options)
         return mark_safe(javascript+html)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:jibaku:places?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:jibaku:places?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)